### PR TITLE
Added keywords to improve plugin findability

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,12 @@
   "keywords": [
     "homebridge-plugin",
     "plugin",
-    "update"
+    "update",
+    "updates",
+    "upgrade",
+    "upgrades",
+    "version",
+    "versions"
   ],
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
## :recycle: Current situation

This plugin is not easy to find as the only keyword is "update".

## :bulb: Proposed solution

Add to the keywords to improve the chances of this plugin being found in a search.

## :heavy_plus_sign: Additional Information

This PR provides a suggested update for feature request [Update keywords](https://github.com/homebridge-plugins/homebridge-plugin-update-check/issues/56)
