### PR TITLE
Fixed field names

### DIFF
--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -4,7 +4,7 @@ export interface PluginUpdatePlatformConfig {
   platform: PlatformName | PlatformIdentifier
   forceNcu?: boolean
   sensorType?: string
-  checkHomebridge?: boolean
-  checkHomebridgeUI?: boolean
-  checkPlugins?: boolean
+  checkHomebridgeUpdates?: boolean
+  checkHomebridgeUIUpdates?: boolean
+  checkPluginUpdates?: boolean
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,9 +66,9 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
     this.isDocker = fs.existsSync('/homebridge/package.json')
     this.sensorInfo = this.getSensorInfo(this.config.sensorType)
 
-    this.checkHB = this.config.checkHomebridge ?? false;
-    this.checkHBUI = this.config.checkHomebridgeUI ?? false;
-    this.checkPlugins = this.config.checkPlugins ?? false;
+    this.checkHB = this.config.checkHomebridgeUpdates ?? false;
+    this.checkHBUI = this.config.checkHomebridgeUIUpdates ?? false;
+    this.checkPlugins = this.config.checkPluginUpdates ?? false;
 
     api.on(APIEvent.DID_FINISH_LAUNCHING, this.addUpdateAccessory.bind(this))
   }
@@ -172,7 +172,7 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
         this.log.error(ex)
       })
       .finally((): void => {
-        this.timer = setTimeout(this.doCheck.bind(this), 8 * 60 * 60 * 1000)
+        this.timer = setTimeout(this.doCheck.bind(this), 60 * 60 * 1000)
       })
   }
 
@@ -294,7 +294,7 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
       this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [newAccessory])
     }
 
-    this.timer = setTimeout(this.doCheck.bind(this), 60 * 1000) // Oznu recommends waiting 60 seconds on start
+    this.timer = setTimeout(this.doCheck.bind(this), 10 * 1000)
   }
 
   getSensorInfo(sensorType?: string): SensorInfo {


### PR DESCRIPTION
## :recycle: Current situation

Got confused during testing and completely tested wrong. Field names were not being loaded from config and defaulting to default values.

## :bulb: Proposed solution

"Test thrice-fix once". Carefully tested each individual combination. Fixed field names and reduced timer delays:
- Initial check 10 seconds after startup
- Recurring checks every 1 hr

## :heavy_plus_sign: Additional Information

Recurring check delay could be added to config and selectable in 1 hr increments.
