### PR TITLE
Output available updates to log

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,38 @@
+# Add 'branding' label to any changes within 'docs' folder or any subfolders
+branding:
+- changed-files:
+  - any-glob-to-any-file: branding/**
+
+# Add 'docs' label to any change to .md files within the entire repository 
+docs:
+- changed-files:
+  - any-glob-to-any-file: '**/*.md'
+
+# Add 'enhancement' label to any change to src files within the source dir EXCEPT for the docs sub-folder
+enhancement:
+  - changed-files:
+    - any-glob-to-any-file: 'src/**/*'
+    - any-glob-to-any-file: 'config.schema.json'
+
+# Add 'dependencies' label to any change to src files within the source dir EXCEPT for the docs sub-folder
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file: 'package.json'
+    - any-glob-to-any-file: 'package-lock.json'
+
+# Add 'beta' label to any PR that is opened against the `beta` branch
+beta:
+- base-branch: 'beta*'
+
+# Add 'alpha' label to any PR that is opened against the `alpha` branch
+alpha:
+- base-branch: 'alpha*'
+
+# Add 'latest' label to any PR that is opened against the `latest` branch
+latest:
+- base-branch: 'latest'
+
+# Add 'workflow' to any changes within 'workflow' folder or any subfolders
+workflow:
+- changed-files:
+  - any-glob-to-any-file: .github/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
       if (homebridge.updateAvailable) {
         updatesAvailable.push(homebridge)
 
-        this.log.debug(`Homebridge update available: ${homebridge.latestVersion}`)
+        this.log.info(`Homebridge update available: ${homebridge.latestVersion}`)
       }
     }
 
@@ -166,7 +166,7 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
         updatesAvailable.push(...filteredPlugins)
 
         filteredPlugins.forEach((plugin) => {
-          this.log.debug(`Homebridge UI update available: ${plugin.latestVersion}`)
+          this.log.info(`Homebridge UI update available: ${plugin.latestVersion}`)
         })
       }
 
@@ -175,7 +175,7 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
         updatesAvailable.push(...filteredPlugins)
 
         filteredPlugins.forEach((plugin) => {
-          this.log.debug(`Homebridge plugin update available: ${plugin.name} ${plugin.latestVersion}`)
+          this.log.info(`Homebridge plugin update available: ${plugin.name} ${plugin.latestVersion}`)
         })
       }
     }
@@ -186,7 +186,7 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
       if (docker.updateAvailable) {
         updatesAvailable.push(docker)
 
-        this.log.debug(`Docker update available: ${docker.latestVersion}`)
+        this.log.info(`Docker update available: ${docker.latestVersion}`)
       }
     }
 


### PR DESCRIPTION
## :recycle: Current situation

Available updates are output to log at debug level, so not available to check.

## :bulb: Proposed solution

Output available versions to log at info level. A user will rarely need to check it, but it might be useful to have in the logs in the event of issues.
