### PR TITLE
Fix plugin update check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,19 +163,23 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
 
       if (this.checkHBUI) {
         const filteredPlugins = plugins.filter(plugin => plugin.name === 'homebridge-config-ui-x')
-        updatesAvailable.push(...filteredPlugins)
 
         filteredPlugins.forEach((plugin) => {
-          this.log.info(`Homebridge UI update available: ${plugin.latestVersion}`)
+          if (plugin.updateAvailable) {
+            updatesAvailable.push(plugin)
+            this.log.info(`Homebridge UI update available: ${plugin.latestVersion}`)
+          }
         })
       }
 
       if (this.checkPlugins) {
         const filteredPlugins = plugins.filter(plugin => plugin.name !== 'homebridge-config-ui-x')
-        updatesAvailable.push(...filteredPlugins)
 
         filteredPlugins.forEach((plugin) => {
-          this.log.info(`Homebridge plugin update available: ${plugin.name} ${plugin.latestVersion}`)
+          if (plugin.updateAvailable) {
+            updatesAvailable.push(plugin)
+            this.log.info(`Homebridge plugin update available: ${plugin.name} ${plugin.latestVersion}`)
+          }
         })
       }
     }


### PR DESCRIPTION
## :recycle: Current situation

Plugins were getting added to list of updates available without checking if updates are actually available.

## :bulb: Proposed solution

Added check to verify if updates are actually available before adding plugins to list of updates available.
