### PR TITLE
Update available update list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,8 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
       if (this.checkPlugins) {
         const filteredPlugins = plugins.filter(plugin => plugin.name !== 'homebridge-config-ui-x')
 
+        const tempUpdates: string[] = []
+
         filteredPlugins.forEach((plugin) => {
           if (plugin.updateAvailable) {
             updatesAvailable.push(plugin)
@@ -271,9 +273,11 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
             if (this.pluginUpdates.length === 0 || !this.pluginUpdates.includes(version)) logLevel = LogLevel.INFO
             this.log.log(logLevel, `Homebridge plugin update available: ${plugin.name} ${plugin.latestVersion}`)
 
-            this.pluginUpdates.push(version)
+            tempUpdates.push(version)
           }
         })
+
+        this.pluginUpdates = tempUpdates
       }
     }
 
@@ -292,7 +296,7 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
       }
     }
 
-    this.log.log(logLevel, `Found ${updatesAvailable.length} available update(s)`)
+    this.log.log(logLevel, `Available update(s): ${updatesAvailable.length}`)
 
     return updatesAvailable.length
   }


### PR DESCRIPTION
## :recycle: Current situation

Currently when a plugin update is found, it is tacked on the end of the list of the found updates. This list is only cleared when HB restarts, so if plugin X has multiple updates, the list of available updates will keep adding versions.

## :bulb: Proposed solution

This fix provides the following remedies:
- Keeps the update list from growing out of control (admittedly not likely, but possible)
- Allows for future ability to display the current list of latest update versions available
