### PR TITLE
Remove double variables for file and directory paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,6 @@ let Accessory: typeof PlatformAccessory
 
 const PLUGIN_NAME = '@homebridge-plugins/homebridge-plugin-update-check'
 const PLATFORM_NAME = 'PluginUpdate'
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 interface SensorInfo {
   serviceType: WithUUID<typeof Service>


### PR DESCRIPTION
The copilot patch was based on the 'latest' branch not on the 'beta'
Because off this there is now a double declaration off some variables

kind regards
