### PR TITLE
Fix error where current Docker version is not found

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -105,14 +105,14 @@
       },
       "autoUpdateHomebridgeUI": {
         "title": "Auto-update Homebridge Config UI",
-        "type": "boolean", 
+        "type": "boolean",
         "description": "Automatically install Homebridge Config UI updates when available (requires homebridge-config-ui-x and sufficient npm privileges)",
         "default": false
       },
       "autoUpdatePlugins": {
         "title": "Auto-update plugins",
         "type": "boolean",
-        "description": "Automatically install plugin updates when available (requires homebridge-config-ui-x and sufficient npm privileges)", 
+        "description": "Automatically install plugin updates when available (requires homebridge-config-ui-x and sufficient npm privileges)",
         "default": false
       },
       "allowDirectNpmUpdates": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { InstalledPlugin, UiApi } from './ui-api.js'
 
 // ESM equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url)
+// eslint-disable-next-line unused-imports/no-unused-vars
 const __dirname = path.dirname(__filename)
 
 let hap: HAP
@@ -161,10 +162,6 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
       },
     )
   }
-
-
-
-
 
   async checkUi(): Promise<number> {
     this.log.debug('Searching for available updates ...')

--- a/src/ui-api.ts
+++ b/src/ui-api.ts
@@ -56,7 +56,8 @@ export class UiApi {
     axiosRetry(axios, {
       retries: 3,
       retryDelay: (...arg) => axiosRetry.exponentialDelay(...arg, 1000),
-      
+
+      // eslint-disable-next-line unused-imports/no-unused-vars
       onRetry: (retryCount, error, _requestConfig) => {
         this.log.debug(`retry count: ${retryCount}, error: ${error.message}`)
       },
@@ -128,20 +129,24 @@ export class UiApi {
 
     if (this.isConfigured() && currentDockerVersion !== undefined) {
       const json = await this.makeDockerCall('/v2/repositories/homebridge/homebridge/tags/?page_size=30&page=1&ordering=last_updated')
-      const versions = json.results as any[]
+      const images = json.results as any[]
 
-      const installedVersion = versions.filter(version => version.name === currentDockerVersion)[0]
-      const installedVersionDate = Date.parse(installedVersion.last_updated)
+      // If the currently installed version is not returned in the list of Docker versions (too old or deleted),
+      // then use a last-updated date Jan 1, 1970
+      const installedImage = images.filter(image => image.name === currentDockerVersion)[0] ?? undefined
+      const installedImageDate = Date.parse(installedImage ? installedImage.last_updated : '1970-01-01T00:00:00.000000Z')
 
-      const availableVersions = versions.filter(version =>
-        !(version.name as string).includes('beta') &&
-        (Date.parse(version.last_updated) > installedVersionDate),
+      // Filter for version names YYYY-MM-DD (no alphas or betas)
+      const regex: RegExp = /^\d{4}-\d{2}-\d{2}$/gm
+      const availableImages = images.filter(image =>
+        (image.name as string).match(regex) &&
+        (Date.parse(image.last_updated) > installedImageDate),
       )
-      if (availableVersions.length > 0) {
+      if (availableImages.length > 0) {
         dockerInfo = {
           name: 'Docker image',
-          installedVersion: installedVersion,
-          latestVersion: availableVersions[0].name,
+          installedVersion: currentDockerVersion,
+          latestVersion: availableImages[0].name,
           updateAvailable: true,
         }
       }


### PR DESCRIPTION
## :recycle: Current situation

The plugin retrieves the last 30 published tags (Docker images). It searches the results using the name of the currently installed Docker version to determine the last-updated date. This is then compared to the latest stable (YYYY-MM-DD) docker image.
If the currently installed version is not found in the returned results (possibly the version is too old or was deleted), then a error occurs trying to read the last-updated date from a non-existent Docker version.

## :bulb: Proposed solution

One option is to increase the page size and retrieve more published tags, however this just kicks the can further down the road and does not solve the case where a particular version was removed from Docker Hub.
The best option is if the current installed version is not found in the results, then assume that that particular version is too old or was deleted and use a last-updated default date of 1970-01-01 for comparison.
