### PR TITLE
Catch errors when checking for Docker updates

### DIFF
--- a/src/ui-api.ts
+++ b/src/ui-api.ts
@@ -334,12 +334,16 @@ export class UiApi {
         return response.data
       })
       .catch((error) => {
-        if (error.code === 'ETIMEOUT') {
-          // Timeout Error (You can implement retry here where suitable)
-          console.error(`Timeout Error connecting to ${this.dockerUrl}`)
+        // At this point, we should have exhausted the retries
 
-          return '{ "count": 0, "results": [] }'
+        if (error.code === 'ETIMEOUT') {
+          console.error(`Timeout error connecting to ${this.dockerUrl}`)
         }
+        else {
+          console.error(`${error.code} error connecting to ${this.dockerUrl}`)
+        }
+
+        return '{ "count": 0, "results": [] }'
       })
   }
 

--- a/src/ui-api.ts
+++ b/src/ui-api.ts
@@ -1,5 +1,5 @@
+/* eslint-disable style/brace-style */
 /* eslint-disable style/operator-linebreak */
-/* eslint-disable object-shorthand */
 /* eslint no-console: ["error", { allow: ["info", "warn", "error"] }] */
 
 import type {
@@ -57,9 +57,8 @@ export class UiApi {
       retries: 3,
       retryDelay: (...arg) => axiosRetry.exponentialDelay(...arg, 1000),
 
-      // eslint-disable-next-line unused-imports/no-unused-vars
-      onRetry: (retryCount, error, _requestConfig) => {
-        this.log.debug(`retry count: ${retryCount}, error: ${error.message}`)
+      onRetry: (retryCount, error, requestConfig) => {
+        this.log.debug(`${requestConfig.url} - retry count: ${retryCount}, error: ${error.message}`)
       },
     })
     this.cacheable = new CacheableLookup()
@@ -325,12 +324,23 @@ export class UiApi {
   }
 
   private async makeDockerCall(apiPath: string): Promise<any> {
-    const response = await axios.get(this.dockerUrl + apiPath, {
-      httpsAgent: this.httpsAgent,
-      lookup: this.cacheable.lookup,
-    })
+    return axios
+      .get(this.dockerUrl + apiPath, {
+        httpsAgent: this.httpsAgent,
+        lookup: this.cacheable.lookup,
+        timeout: 60000,
+      })
+      .then((response) => {
+        return response.data
+      })
+      .catch((error) => {
+        if (error.code === 'ETIMEOUT') {
+          // Timeout Error (You can implement retry here where suitable)
+          console.error(`Timeout Error connecting to ${this.dockerUrl}`)
 
-    return response.data
+          return '{ "count": 0, "results": [] }'
+        }
+      })
   }
 
   private async makeCall(apiPath: string): Promise<unknown> {


### PR DESCRIPTION
## :recycle: Current situation

When checking for Docker updates, if a timeout occurs, the error is not caught and a stack trace is output to the logs.

## :bulb: Proposed solution

Add error management when checking for Docker updates.

Fix for [🐞 Bug: Timeout error in logs](https://github.com/homebridge-plugins/homebridge-plugin-update-check/issues/194)
