### PR TITLE
Added warning for old version of Homebridge UI

### DIFF
--- a/src/ui-api.ts
+++ b/src/ui-api.ts
@@ -426,7 +426,7 @@ export class UiApi {
 
         this.log.error(`${error.code} error connecting to ${this.baseUrl + apiPath}`)
         if (error.code === 'ERR_BAD_REQUEST' && error.status === 404 && apiPath === ApiPluginEndpoints.getIgnoredPluginList) {
-          this.log.debug(`Error: ${JSON.stringify(error)}`)
+          this.log.debug(`Error: ${JSON.stringify(error, undefined, 2)}`)
           this.log.warn(`This feature requires a newer version of Homebridge UI. Please update to the latest version.`)
         }
 

--- a/src/ui-api.ts
+++ b/src/ui-api.ts
@@ -425,7 +425,8 @@ export class UiApi {
         // At this point, we should have exhausted the retries
 
         this.log.error(`${error.code} error connecting to ${this.baseUrl + apiPath}`)
-        if (error.code === 'ERR_BAD_REQUEST' && apiPath === ApiPluginEndpoints.getIgnoredPluginList) {
+        if (error.code === 'ERR_BAD_REQUEST' && error.status === 404 && apiPath === ApiPluginEndpoints.getIgnoredPluginList) {
+          this.log.debug(`Error: ${JSON.stringify(error)}`)
           this.log.warn(`This feature requires a newer version of Homebridge UI. Please update to the latest version.`)
         }
 

--- a/src/ui-api.ts
+++ b/src/ui-api.ts
@@ -40,6 +40,12 @@ interface UiConfig {
   }
 }
 
+class ApiPluginEndpoints {
+  static readonly getHomebridgeVersion = '/api/status/homebridge-version'
+  static readonly getPluginList = '/api/plugins'
+  static readonly getIgnoredPluginList = '/api/config-editor/ui/plugins/hide-updates-for'
+}
+
 export class UiApi {
   private log: Logging
   private readonly secrets?: SecretsFile
@@ -98,7 +104,7 @@ export class UiApi {
 
   public async getHomebridge(): Promise<InstalledPlugin> {
     if (this.isConfigured()) {
-      const result = await this.makeCall('/api/status/homebridge-version') as Array<InstalledPlugin>
+      const result = await this.makeCall(ApiPluginEndpoints.getHomebridgeVersion) as Array<InstalledPlugin>
 
       if (result.length > 0) {
         return result[0]
@@ -115,7 +121,7 @@ export class UiApi {
 
   public async getPlugins(): Promise<Array<InstalledPlugin>> {
     if (this.isConfigured()) {
-      return await this.makeCall('/api/plugins') as Array<InstalledPlugin>
+      return await this.makeCall(ApiPluginEndpoints.getPluginList) as Array<InstalledPlugin>
     } else {
       return []
     }
@@ -124,8 +130,7 @@ export class UiApi {
   public async getIgnoredPlugins(): Promise<Array<string>> {
     if (this.isConfigured()) {
       try {
-        this.log.debug('Calling /api/config-editor/ui/plugins/hide-updates-for API endpoint')
-        const result = await this.makeCall('/api/config-editor/ui/plugins/hide-updates-for')
+        const result = await this.makeCall(ApiPluginEndpoints.getIgnoredPluginList)
 
         // Validate the response format
         if (!Array.isArray(result)) {
@@ -420,6 +425,9 @@ export class UiApi {
         // At this point, we should have exhausted the retries
 
         this.log.error(`${error.code} error connecting to ${this.baseUrl + apiPath}`)
+        if (error.code === 'ERR_BAD_REQUEST' && apiPath === ApiPluginEndpoints.getIgnoredPluginList) {
+          this.log.warn(`This feature requires a newer version of Homebridge UI. Please update to the latest version.`)
+        }
 
         return []
       })


### PR DESCRIPTION
## :recycle: Current situation

When running on an older version of Homebridge UI, the call to get ignored plugins fails with ERR_BAD_REQUEST error, as there is only a PUT endpoint and no GET endpoint.

## :bulb: Proposed solution

The best solution going forward is to catch ERR_BAD_REQUEST errors and if they are generated as a response to the call to get ignored plugins, then output a warning to the logs that this functionality requires a newer version of Homebridge UI and the user should update.

## :gear: Release Notes

This code fix should be accompanied by a warning on the UI that ignoring updates for ignored plugins will not work on older versions of Homebridge UI and the and the user should update to the latest version if they want to use this feature.

## :heavy_plus_sign: Additional Information

Logs as currently output by Homebridge UI v5.4.1:

<img width="1310" height="101" alt="Screenshot 2025-10-05 at 3 38 22 PM" src="https://github.com/user-attachments/assets/7aae1528-9ebc-4095-bda8-89523c1785c9" />

This PR addresses issue #199 - [🐞 Bug: ERR_BAD_REQUEST error connecting to http://localhost:8581/api/config-editor/ui/plugins/hide-updates-for](https://github.com/homebridge-plugins/homebridge-plugin-update-check/issues/199)
