### PR TITLE
Add Homebridge UI version warning

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -180,6 +180,12 @@
         "type": "boolean",
         "description": "When enabled, respects the 'Hide update notifications for this plugin' setting from homebridge-config-ui-x. Plugins marked to hide updates will not trigger notifications.",
         "default": true
+      },
+      "": {
+        "title": "",
+        "description": "Note: This feature may require updating Homebridge UI to a newer varsion. It is recommended to update to the latest version.",
+        "type": "object",
+        "properties": {}
       }
     },
     "required": ["name", "sensorType"]


### PR DESCRIPTION
## :recycle: Current situation

The `Respect disabled plugin update notifications` feature requires a new API endpoint in a recent version of Homebridge UI

## :bulb: Proposed solution

Add a notice that the `Respect disabled plugin update notifications` feature may not work with older versions of Homebridge UI and it is recommended to update to the latest version.

## :gear: Release Notes

The `Respect disabled plugin update notifications` feature may not work with older versions of Homebridge UI. It is recommended to update to the latest version.

## :heavy_plus_sign: Additional Information

<img width="776" height="168" alt="Screenshot 2025-10-05 at 11 23 43 PM" src="https://github.com/user-attachments/assets/f26e1c4e-0b6f-4b05-8b8e-abaa26ac73bc" />

Provides fix for issue [🐞 Bug: Add warning on UI for old version of Homebridge UI](https://github.com/homebridge-plugins/homebridge-plugin-update-check/issues/201)