### PR TITLE
Use `log.debug` for all ignored updates and suppress when no updates available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -279,7 +279,7 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
             ignoredPlugins.includes(plugin.name),
           )
           if (ignoredWithUpdates.length > 0) {
-            this.log.info(`Ignoring updates for ${ignoredWithUpdates.length} plugin(s): ${ignoredWithUpdates.map(p => p.name).join(', ')}`)
+            this.log.debug(`Ignoring updates for ${ignoredWithUpdates.length} plugin(s): ${ignoredWithUpdates.map(p => p.name).join(', ')}`)
           }
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,7 +300,9 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
       }
     }
 
-    this.log.log(logLevel, `Found ${updatesAvailable.length} available update(s)`)
+    if (updatesAvailable.length > 0) {
+      this.log.log(logLevel, `Found ${updatesAvailable.length} available update(s)`)
+    }
 
     // Provide additional diagnostic information in debug mode
     if (this.respectDisabledPlugins && ignoredPlugins.length > 0) {


### PR DESCRIPTION
## :recycle: Current situation

Currently, when updates for a particular plugin are ignored, the log is littered with messages:

```
[12/17/2025, 11:05:00 AM] [Plugin Update] Ignoring updates for 1 plugin(s): @homebridge-plugins/homebridge-govee
[12/17/2025, 12:05:00 PM] [Plugin Update] Ignoring updates for 1 plugin(s): @homebridge-plugins/homebridge-govee
[12/17/2025, 1:05:00 PM] [Plugin Update] Ignoring updates for 1 plugin(s): @homebridge-plugins/homebridge-govee
[12/17/2025, 2:05:00 PM] [Plugin Update] Ignoring updates for 1 plugin(s): @homebridge-plugins/homebridge-govee
[12/17/2025, 3:05:00 PM] [Plugin Update] Ignoring updates for 1 plugin(s): @homebridge-plugins/homebridge-govee
[12/17/2025, 4:05:00 PM] [Plugin Update] Ignoring updates for 1 plugin(s): @homebridge-plugins/homebridge-govee
```

Also, when there are no updates available, there is an unnecessary message that 0 updates are available:

```
[12/17/2025, 11:00:00 AM] [Plugin Update] Found 0 available update(s)
```

## :bulb: Proposed solution

When HB core or UI updates are ignored, the message is only logged to debug. This PR updates ignored plugin checks to match.

Further, this PR suppresses the log message when there are 0 updates, following the "silence is golden" philosophy

## :gear: Release Notes

Removed unnecessary logging for 0 updates or when plugin updates that are ignored

## :heavy_plus_sign: Additional Information

N/A

### Testing

No tests added. Logging only.

### Reviewer Nudging

Pretty straightforward change 😁