### PR TITLE
Unref croner cron jobs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,7 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
       {
         name: `First Daily Run Reset Cron Job`,
         timezone: timezone,
+        unref: true,
       },
       async () => {
         this.firstDailyRun = true
@@ -156,6 +157,7 @@ class PluginUpdatePlatform implements DynamicPlatformPlugin {
       {
         name: `Updates Available Cron Job`,
         timezone: timezone,
+        unref: true,
       },
       async () => {
         this.log.debug(`Is first daily run: ${this.firstDailyRun}`)


### PR DESCRIPTION
## :recycle: Current situation

Croner cron jobs were not "unref"'d, meaning that they could keep Node from restarting.

## :bulb: Proposed solution

Added `unref: true` option to all cron jobs.

## :gear: Release Notes

Modified `index.ts` to update cron job options.
